### PR TITLE
:bug:-fix(es) in UNIX/Windows buildtools

### DIFF
--- a/configure
+++ b/configure
@@ -182,7 +182,14 @@ if [ "$(( PREINSTALLED + FORCE_VENDOR ))" -ne 0 ]; then
     TALIB="src/ta-lib" # vendor location
     
     ## vendor check start
-    if [ ! -d "$TALIB" ]; then
+    ##  it's NOT enough to check for $TALIB as
+    ##  the folder gets cloned, but its empty, 
+    ##  and therefore never enters the branch.
+    ##      - instead of checking for the folder
+    ##        we check for CMakeLists.txt inside the
+    ##        folder, which is safe because if its not
+    ##        there - then {talib} can't build anyways.
+    if  [ ! -f "$TALIB/CMakeLists.txt" ]; then
 
         if ! command -v git > /dev/null 2>&1; then
             printf ' %s\n' "$(warning)"
@@ -221,16 +228,16 @@ if [ "$(( PREINSTALLED + FORCE_VENDOR ))" -ne 0 ]; then
         ## version is being installed via {pak} or other tools which does not 
         ## include submodules by default
         else
-        printf ' %s\n' "$(warning)"
-        echo
-        echo "TA-Lib (core) not found. Cloning $(url https://github.com/TA-Lib/ta-lib.git)"
-        echo
-        git clone https://github.com/TA-Lib/ta-lib.git ${TALIB} || {
+            printf ' %s\n' "$(warning)"
+            echo
+            echo "TA-Lib (core) not found. Cloning $(url https://github.com/TA-Lib/ta-lib.git)"
+            echo
+            git clone https://github.com/TA-Lib/ta-lib.git ${TALIB} || {
 
-            echo $(error) Could not clone $(url https://github.com/TA-Lib/ta-lib.git).
-            echo Check your internet connection, or submit a bug-report.
-            exit 1
-            }
+                echo $(error) Could not clone $(url https://github.com/TA-Lib/ta-lib.git).
+                echo Check your internet connection, or submit a bug-report.
+                exit 1
+                }
         fi
 
     fi
@@ -238,44 +245,30 @@ if [ "$(( PREINSTALLED + FORCE_VENDOR ))" -ne 0 ]; then
     ## vendor check end
     TARGET="$(cd "$TALIB" 2>/dev/null && pwd)/local"
 
-    ## NOTE: this builds a temporary
-    ##       directory to build TA-Lib
-    ##       without this step .Rbuildignore will riot.
-    ##       $TARGET must NOT be cleaned here — R CMD INSTALL
-    ##       links against libta-lib.a inside it after configure
-    ##       completes.
-    BUILDLOCATION=$(temporary_directory)
-    trap 'rm -rf "$BUILDLOCATION"' EXIT
-
-    if command -v cmake >/dev/null 2>&1 && [ -f "$TALIB/CMakeLists.txt" ]; then
-        printf '%s Configure and generate TA-Lib\n' "$(info)"
-
-        cmake -S "$TALIB" -B "${BUILDLOCATION}" \
-            -Wno-dev --log-level=NOTICE \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_INSTALL_PREFIX="$TARGET" \
-            -DBUILD_SHARED_LIBS=OFF \
-            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-            -DCMAKE_C_FLAGS="-w -fPIC ${OPTFLAGS}" \
-            -DCMAKE_CXX_FLAGS="-w -fPIC ${OPTFLAGS}" \
-            -DBUILD_DEV_TOOLS=OFF
-
-        printf '%s\n' "$(success)"
-
-        printf '%s Build and install TA-Lib\n' "$(info)"
-
-        cmake --build "${BUILDLOCATION}" --target install -- -j"$(nproc --ignore 2)"
-
-        printf '%s\n' "$(success)"
-
-    else
+    ## find CMake on PATH before proceeding
+    ## with the build - this approach is necessary
+    ## for MacOS which in (some) cases are located
+    ## in a different PATH than otherwise.
+    ##  - This approach is a part 'Writing R Extensions' and
+    ##    is also recommended by Dirk Eddelbuettel.
+    if test -z "${CMAKE:-}"; then
+        # Look for a cmake binary in the current path
+        CMAKE=`which cmake 2>/dev/null`
+    fi
+    
+    if test -z "${CMAKE:-}"; then
+        # Check for a MacOS specific path
+        CMAKE=`which /Applications/CMake.app/Contents/bin/cmake 2>/dev/null`
+    fi
+    
+    if test -z "${CMAKE:-}"; then  
         ## NOTE: after many attempts I can't make 
         ##       configure "work" using libtools. It either complains about
         ##       missing libraries, or links.
         ##
         ##       CMake just works well here, end of story.
         printf ' %s\n' "$(error)"
-        printf 'CMake not found on PATH'
+        printf 'CMake not found on PATH\n'
         echo "=========================================================================="
         echo "Install CMake:"
         echo "  Linux:"
@@ -294,6 +287,37 @@ if [ "$(( PREINSTALLED + FORCE_VENDOR ))" -ne 0 ]; then
         echo "Submit bug-reports here: $(url https://github.com/serkor1/ta-lib-R)"
         echo
         exit 1
+    fi
+
+    ## NOTE: this builds a temporary
+    ##       directory to build TA-Lib
+    ##       without this step .Rbuildignore will riot.
+    ##       $TARGET must NOT be cleaned here — R CMD INSTALL
+    ##       links against libta-lib.a inside it after configure
+    ##       completes.
+    BUILDLOCATION=$(temporary_directory)
+    trap 'rm -rf "$BUILDLOCATION"' EXIT
+
+    if command -v "${CMAKE}" >/dev/null 2>&1; then
+        printf '%s Configure and generate TA-Lib\n' "$(info)"
+
+        ${CMAKE} -S "$TALIB" -B "${BUILDLOCATION}" \
+            -Wno-dev --log-level=NOTICE \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$TARGET" \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+            -DCMAKE_C_FLAGS="-w -fPIC ${OPTFLAGS}" \
+            -DCMAKE_CXX_FLAGS="-w -fPIC ${OPTFLAGS}" \
+            -DBUILD_DEV_TOOLS=OFF
+
+        printf '%s\n' "$(success)"
+
+        printf '%s Build and install TA-Lib\n' "$(info)"
+
+        ${CMAKE} --build "${BUILDLOCATION}" --target install -- -j"$(nproc --ignore 2)"
+
+        printf '%s\n' "$(success)"        
     fi
 
 fi

--- a/configure.win
+++ b/configure.win
@@ -101,7 +101,7 @@ rm -rf "$TESTDIR"
 
 ## 1) general setup of
 ##    the configure script
-TA_SRC="src/ta-lib"
+TALIB="src/ta-lib"
 CC_BIN="${CC:-cc}"
 
 ## 1.1) determine processors
@@ -118,7 +118,7 @@ nprocs() {
 ##      correctly and determine an action
 ##      conditional of how the repository
 ##      have been downloaded
-if [ ! -d "$TA_SRC" ]; then
+if [ ! -f "$TALIB/CMakeLists.txt" ]; then
 
    ## check if git is available
     ## on the system
@@ -145,7 +145,7 @@ if [ ! -d "$TA_SRC" ]; then
   ## so this part is "just" to give the developer a helpful
   ## message
   if git status > /dev/null 2>&1; then
-      echo "Build-error: $TA_SRC not found. Either make a new clone, or initialize the submodule."
+      echo "Build-error: $TALIB not found. Either make a new clone, or initialize the submodule."
       echo 
       echo "Clone: \t\t git clone --recursive https://github.com/serkor1/ta-lib-R.git"
       echo "Initialize: \t git submodule update --init --recursive"
@@ -162,7 +162,7 @@ if [ ! -d "$TA_SRC" ]; then
     echo
     echo "TA-Lib (core) not found. Cloning https://github.com/TA-Lib/ta-lib.git"
     echo
-    git clone https://github.com/TA-Lib/ta-lib.git ${TA_SRC} || {
+    git clone https://github.com/TA-Lib/ta-lib.git ${TALIB} || {
         echo
         echo "Build-error: Could not clone https://github.com/TA-Lib/ta-lib.git. Check your internet connection, or submit a bug-report."
         echo
@@ -219,7 +219,7 @@ GEN="MinGW Makefiles"; command -v ninja >/dev/null 2>&1 && GEN="Ninja"
 ##            and for (it seems) everyone else except
 ##            GHA workflows.
 ##
-if ! cmake -S "$TA_SRC" -B "$BUILDROOT/cmake" -G "$GEN" \
+if ! cmake -S "$TALIB" -B "$BUILDROOT/cmake" -G "$GEN" \
   -Wno-dev --log-level=NOTICE \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX="$OUT_PREFIX" \
@@ -230,7 +230,7 @@ if ! cmake -S "$TA_SRC" -B "$BUILDROOT/cmake" -G "$GEN" \
 then
   rm -rf "$BUILDROOT/cmake"
   GEN="MSYS Makefiles"
-  if ! cmake -S "$TA_SRC" -B "$BUILDROOT/cmake" -G "$GEN" \
+  if ! cmake -S "$TALIB" -B "$BUILDROOT/cmake" -G "$GEN" \
     -Wno-dev --log-level=NOTICE \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX="$OUT_PREFIX" \
@@ -256,8 +256,8 @@ cmake --install "$BUILDROOT/cmake" --config Release --prefix "$OUT_PREFIX"
 ##        NOTE: this might be a dangerous
 ##              step if pathing and naming
 ##              gets changed upstream.
-if [ -f "$TA_SRC/include/ta_config.h" ]; then
-  tmp="$(mktemp)"; tr -d '\r' < "$TA_SRC/include/ta_config.h" > "$tmp" && mv "$tmp" "$TA_SRC/include/ta_config.h"
+if [ -f "$TALIB/include/ta_config.h" ]; then
+  tmp="$(mktemp)"; tr -d '\r' < "$TALIB/include/ta_config.h" > "$tmp" && mv "$tmp" "$TALIB/include/ta_config.h"
 fi
 
 ## 2.3) construct flags


### PR DESCRIPTION
## :books: What?

{talib} errors on MacOS on CRAN machines because CMake is not on the default PATH and the current `configure` assumes PATH of the CMake - which is clearly incorrect. The `configure` now follows *Writing R Extensions* and the advice of Dirk Eddelbuettel more closely. An unrelated bug were identified during the discussions whic is also fixed in this PR (see #46 or #44 for more details).

This PR does the following: 

* Following 'Writing R Extensions' the CMake is now probed programmatically and stored in an environment variable. This ensures that CMake is found on the relevant PATH, instead of assuming its on the default PATH.

* When cloning from Github src/ta-lib follows, but its empty. So the cloner will never see the relevant error message because the branch is never entered because the folder exists. The correct approach is to look for the relevant CMakeLists.txt, and if its not there it will enter the branch.

This PR closes https://github.com/serkor1/ta-lib-R/issues/46 and/or https://github.com/serkor1/ta-lib-R/issues/44