### PR TITLE
:hammer: R-universe tests

### DIFF
--- a/.github/workflows/r-universe.yaml
+++ b/.github/workflows/r-universe.yaml
@@ -5,7 +5,7 @@ name: Test R-universe
 
 on:
   push:
-    branches: [devel, r-universe-checks]
+    branches: [devel]
   pull_request:
     branches: [devel]
 

--- a/.github/workflows/r-universe.yaml
+++ b/.github/workflows/r-universe.yaml
@@ -59,6 +59,9 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
+    outputs:
+      sha: ${{ steps.push.outputs.sha }}
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -81,6 +84,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Commit rendered docs and push
+        id: push
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -88,6 +92,7 @@ jobs:
           git add -f man/ NAMESPACE
           git commit --allow-empty -m "CI/CD: render documentation for r-universe build"
           git push origin r-universe/check-pkg
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   build:
     needs: render-documentation
@@ -95,7 +100,7 @@ jobs:
     uses: r-universe-org/workflows/.github/workflows/build.yml@v3
     with:
       universe: ${{ github.repository_owner }}
-      ref: r-universe/check-pkg
+      ref: ${{ needs.render-documentation.outputs.sha }}
 
   cleanup:
     needs: [render-documentation, build]

--- a/.github/workflows/r-universe.yaml
+++ b/.github/workflows/r-universe.yaml
@@ -1,0 +1,41 @@
+name: Test R-universe
+
+on:
+  push:
+    branches: [devel, r-universe-checks]
+  pull_request:
+    branches: [devel]
+
+jobs:
+  render-documentation:
+    name: Render documentation and NAMESPACE
+    runs-on: ubuntu-latest
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: release
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::devtools any::roxygen2
+          needs: check
+
+      - name: Render documentation and NAMESPACE
+        run: devtools::document()
+        shell: Rscript {0}
+
+  build:
+    needs: render-documentation
+    name: R-universe testing
+    uses: r-universe-org/workflows/.github/workflows/build.yml@v3
+    with:
+      universe: ${{ github.repository_owner }}

--- a/.github/workflows/r-universe.yaml
+++ b/.github/workflows/r-universe.yaml
@@ -1,3 +1,6 @@
+## this workflow is primarily meant
+## for testing against CRAN-systems and 
+## not for aligning against r-universe.
 name: Test R-universe
 
 on:
@@ -6,8 +9,50 @@ on:
   pull_request:
     branches: [devel]
 
+## the permission has to be 
+## set to write so we are allowed
+## to create a new branch
+permissions:
+  contents: write
+
+## this section is important
+## for this workflow - the 
+## branch it works off of is 
+## fixed, so if there is multiple pushes
+## it will cancel the old ones
+concurrency:
+  group: r-universe-check
+  cancel-in-progress: true
+
 jobs:
+  ## r-universe builds directly from
+  ## the repository its being run from
+  ## without modifictions to the actual runs.
+  ## this means that untracked .Rd files never
+  ## enters the build/check - to mitigate this
+  ## we create a temporary branch where the .Rd
+  ## files are pushed, and let r-universe build
+  ## and test from there
+  create-branch:
+    name: Temporary branch creation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+
+      - name: Create and push r-universe/check-pkg
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B r-universe/check-pkg
+          git push --force origin r-universe/check-pkg
+
+  ## this step builds and pushes
+  ## the documentation to the temporary branch
   render-documentation:
+    needs: create-branch
     name: Render documentation and NAMESPACE
     runs-on: ubuntu-latest
 
@@ -17,7 +62,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: r-universe/check-pkg
           submodules: recursive
+          persist-credentials: true
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -33,9 +80,28 @@ jobs:
         run: devtools::document()
         shell: Rscript {0}
 
+      - name: Commit rendered docs and push
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -f man/ NAMESPACE
+          git commit --allow-empty -m "CI/CD: render documentation for r-universe build"
+          git push origin r-universe/check-pkg
+
   build:
     needs: render-documentation
     name: R-universe testing
     uses: r-universe-org/workflows/.github/workflows/build.yml@v3
     with:
       universe: ${{ github.repository_owner }}
+      ref: r-universe/check-pkg
+
+  cleanup:
+    needs: [render-documentation, build]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Delete temporary branch
+        run: git push origin --delete r-universe/check-pkg || true

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 <!-- badges: start -->
 
 [![R-CMD-check](https://github.com/serkor1/ta-lib-R/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/serkor1/ta-lib-R/actions/workflows/R-CMD-check.yaml)
+[![Test
+R-universe](https://github.com/serkor1/ta-lib-R/actions/workflows/r-universe.yaml/badge.svg)](https://github.com/serkor1/ta-lib-R/actions/workflows/r-universe.yaml)
 [![Remote
 Install](https://github.com/serkor1/ta-lib-R/actions/workflows/remote-install.yaml/badge.svg)](https://github.com/serkor1/ta-lib-R/actions/workflows/remote-install.yaml)
 [![Codecov test

--- a/configure
+++ b/configure
@@ -95,6 +95,11 @@ for arg in "$@"; do
     --force-vendor)
       FORCE_VENDOR=1
       ;;
+    ## autotools-style arguments injected by `emconfigure` (and by other
+    ## cross-compile harnesses) — dropped so they don't leak into
+    ## CMAKE_C_FLAGS and get handed to the compiler as unknown flags.
+    --build=*|--host=*|--target=*|ac_cv_*=*)
+      ;;
     *)
       OPTFLAGS="${OPTFLAGS} ${arg}"
       ;;

--- a/configure.win
+++ b/configure.win
@@ -29,6 +29,11 @@ for arg in "$@"; do
       echo "{talib} on Windows will always use the vendored TA-Lib source."
       echo "Feel free to submit a PR, if you have a solid solution to Windows + {talib} using system/user-installed TA-Lib."
       ;;
+    ## autotools-style arguments injected by cross-compile harnesses —
+    ## dropped so they don't leak into CMAKE_C_FLAGS as unknown compiler
+    ## flags. Kept parallel with the UNIX `configure` script.
+    --build=*|--host=*|--target=*|ac_cv_*=*)
+      ;;
     *)
       OPTFLAGS="${OPTFLAGS} ${arg}"
       ;;

--- a/dev/README.Rmd
+++ b/dev/README.Rmd
@@ -37,6 +37,7 @@ BTC <- tail(talib::BTC, 150)
 
 <!-- badges: start -->
 [![R-CMD-check](https://github.com/serkor1/ta-lib-R/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/serkor1/ta-lib-R/actions/workflows/R-CMD-check.yaml)
+[![Test R-universe](https://github.com/serkor1/ta-lib-R/actions/workflows/r-universe.yaml/badge.svg)](https://github.com/serkor1/ta-lib-R/actions/workflows/r-universe.yaml)
 [![Remote Install](https://github.com/serkor1/ta-lib-R/actions/workflows/remote-install.yaml/badge.svg)](https://github.com/serkor1/ta-lib-R/actions/workflows/remote-install.yaml)
 [![Codecov test coverage](https://codecov.io/gh/serkor1/ta-lib-R/graph/badge.svg)](https://app.codecov.io/gh/serkor1/ta-lib-R)
 [![CRAN status](https://www.r-pkg.org/badges/version/talib)](https://CRAN.R-project.org/package=talib)


### PR DESCRIPTION
## :books: What?

After submission to CRAN issues #44 and #45 emerged. While both issues were related to `configure` and `configure.win` it went unnoticed before arriving at CRAN, because the setup is different from GHA - a possible solution, as suggested by Dirk Eddelbuettel, was to use `r-universe`-tests. This PR implements just that: `r-universe`-tests, which are closer to CRAN machines than `R CMD check` on Github. `r-universe` also builds on WASM, which the `configure` now also supports, by separating relevant flags.

**NOTE:** Its overkill to have `R CMD check` and `r-universe`-tests, but that is for a separate PR.

This PR closes #45 (Will be reopened if CRAN fails again, but that is highly unlikely.)