### PR TITLE
:hammer: Support for cached builds

### DIFF
--- a/.github/workflows/remote-install.yaml
+++ b/.github/workflows/remote-install.yaml
@@ -13,6 +13,7 @@ on:
     paths:
       - 'configure'
       - 'configure.win'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -21,7 +22,9 @@ concurrency:
 permissions: read-all
 
 jobs:
-  R-CMD-check:
+  ## Vanilla remote install - verifies pak::pak("serkor1/ta-lib-R")
+  ## works on a clean runner with no compiler-wrapping in ~/.R/Makevars.
+  Remote-Install:
     runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
@@ -39,7 +42,7 @@ jobs:
           - {os: windows-latest, r: 'devel', http-user-agent: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: windows-latest, r: 'oldrel-1'}
-          
+
           # Ubuntu
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
@@ -68,6 +71,108 @@ jobs:
       - name: Install {talib}
         run: pak::pak("serkor1/ta-lib-R")
         shell: Rscript {0}
+
+      - name: Calculate an indicator
+        run: talib::bollinger_bands(talib::BTC)
+        shell: Rscript {0}
+
+  ## Remote install with ccache configured in ~/.R/Makevars - regression
+  ## guard for https://github.com/serkor1/ta-lib-R/issues/57, where installs
+  ## with `CC = ccache gcc` in Makevars hit
+  ## "/usr/bin/ccache: invalid option -- 'D'" because the configure script
+  ## passed `CMAKE_C_COMPILER=ccache` and CMake then invoked ccache with
+  ## raw `-D` definitions.
+  Remote-Install-ccache:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }}, ccache)
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          ## macOS
+          - {os: macos-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: macos-latest,   r: 'release'}
+          - {os: macos-latest,   r: 'oldrel-1'}
+
+          ## windows
+          - {os: windows-latest, r: 'devel', http-user-agent: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: windows-latest, r: 'oldrel-1'}
+
+          # Ubuntu
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - name: Install ccache (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y ccache
+        shell: bash
+
+      - name: Install ccache (macOS)
+        if: runner.os == 'macOS'
+        run: brew install ccache
+        shell: bash
+
+      - name: Install ccache (Windows)
+        if: runner.os == 'Windows'
+        run: choco install ccache -y --no-progress
+        shell: pwsh
+
+      - name: Configure ~/.R/Makevars to use ccache
+        run: |
+          dir <- path.expand(file.path("~", ".R"))
+          dir.create(dir, recursive = TRUE, showWarnings = FALSE)
+          name <- if (.Platform$OS.type == "windows") "Makevars.win" else "Makevars"
+          if (Sys.info()[["sysname"]] == "Darwin") {
+            cc <- "clang"; cxx <- "clang++"
+          } else {
+            cc <- "gcc";  cxx <- "g++"
+          }
+          path <- file.path(dir, name)
+          writeLines(
+            c(paste0("CC=ccache ",  cc),
+              paste0("CXX=ccache ", cxx)),
+            path
+          )
+          cat("--- ", path, " ---\n", sep = "")
+          cat(readLines(path), sep = "\n"); cat("\n")
+        shell: Rscript {0}
+
+      - name: Reset ccache statistics
+        run: ccache --zero-stats
+        shell: bash
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pak any::plotly any::devtools any::roxygen2
+          needs: check
+
+      - name: Install {talib}
+        run: pak::pak("serkor1/ta-lib-R")
+        shell: Rscript {0}
+
+      - name: Show ccache statistics
+        if: always()
+        run: ccache -s
+        shell: bash
 
       - name: Calculate an indicator
         run: talib::bollinger_bands(talib::BTC)

--- a/configure
+++ b/configure
@@ -152,6 +152,25 @@ R_CXXFLAGS=$("$R_BIN" CMD config CXXFLAGS)
 R_CPPFLAGS=$("$R_BIN" CMD config CPPFLAGS)
 R_LDFLAGS=$("$R_BIN" CMD config LDFLAGS)
 
+## Detect a compiler launcher (ccache/sccache/distcc) baked into
+## R's CC/CXX by ~/.R/Makevars and hand it to CMake via
+## CMAKE_<LANG>_COMPILER_LAUNCHER. Without this CMake invokes
+## "ccache -Dfoo ..." directly and ccache misreads -D as its own
+## debug-level flag (#57).
+LAUNCHER_ARGS=""
+case "$(basename "${R_CC_FULL%% *}")" in
+    ccache|sccache|distcc)
+        LAUNCHER_ARGS="$LAUNCHER_ARGS -DCMAKE_C_COMPILER_LAUNCHER=${R_CC_FULL%% *}"
+        R_CC_FULL="${R_CC_FULL#* }"
+        ;;
+esac
+case "$(basename "${R_CXX_FULL%% *}")" in
+    ccache|sccache|distcc)
+        LAUNCHER_ARGS="$LAUNCHER_ARGS -DCMAKE_CXX_COMPILER_LAUNCHER=${R_CXX_FULL%% *}"
+        R_CXX_FULL="${R_CXX_FULL#* }"
+        ;;
+esac
+
 ## details:
 ##  R CMD config returns the compiler with leading flags baked in
 ##  (e.g. "clang -arch x86_64" or "/opt/R/x86_64/bin/clang -arch
@@ -440,6 +459,7 @@ if [ "$(( PREINSTALLED + FORCE_VENDOR ))" -ne 0 ]; then
             -DCMAKE_EXE_LINKER_FLAGS="$R_LDFLAGS" \
             -DCMAKE_SHARED_LINKER_FLAGS="$R_LDFLAGS" \
             $OSX_CMAKE_ARGS \
+            $LAUNCHER_ARGS \
             -DBUILD_DEV_TOOLS=OFF
 
         printf '%s\n' "$(success)"

--- a/configure.win
+++ b/configure.win
@@ -86,6 +86,25 @@ R_CXXFLAGS=$("$R_BIN" CMD config CXXFLAGS)
 R_CPPFLAGS=$("$R_BIN" CMD config CPPFLAGS)
 R_LDFLAGS=$("$R_BIN" CMD config LDFLAGS)
 
+## Detect a compiler launcher (ccache/sccache/distcc) baked into
+## R's CC/CXX by ~/.R/Makevars and hand it to CMake via
+## CMAKE_<LANG>_COMPILER_LAUNCHER. Without this CMake invokes
+## "ccache -Dfoo ..." directly and ccache misreads -D as its own
+## debug-level flag (#57).
+LAUNCHER_ARGS=""
+case "$(basename "${R_CC_FULL%% *}")" in
+    ccache|sccache|distcc)
+        LAUNCHER_ARGS="$LAUNCHER_ARGS -DCMAKE_C_COMPILER_LAUNCHER=${R_CC_FULL%% *}"
+        R_CC_FULL="${R_CC_FULL#* }"
+        ;;
+esac
+case "$(basename "${R_CXX_FULL%% *}")" in
+    ccache|sccache|distcc)
+        LAUNCHER_ARGS="$LAUNCHER_ARGS -DCMAKE_CXX_COMPILER_LAUNCHER=${R_CXX_FULL%% *}"
+        R_CXX_FULL="${R_CXX_FULL#* }"
+        ;;
+esac
+
 R_CC=$(echo "$R_CC_FULL" | awk '{print $1}')
 R_CC_EXTRA=$(echo "$R_CC_FULL" | cut -s -d' ' -f2-)
 R_CXX=$(echo "$R_CXX_FULL" | awk '{print $1}')
@@ -265,6 +284,7 @@ if ! cmake -S "$TALIB" -B "$BUILDROOT/cmake" -G "$GEN" \
   -DCMAKE_CXX_FLAGS="$R_CXX_EXTRA $R_CXXFLAGS $R_CPPFLAGS -w ${OPTFLAGS}" \
   -DCMAKE_EXE_LINKER_FLAGS="$R_LDFLAGS" \
   -DCMAKE_SHARED_LINKER_FLAGS="$R_LDFLAGS" \
+  $LAUNCHER_ARGS \
   -DBUILD_DEV_TOOLS=OFF
 then
   rm -rf "$BUILDROOT/cmake"
@@ -281,6 +301,7 @@ then
     -DCMAKE_CXX_FLAGS="$R_CXX_EXTRA $R_CXXFLAGS $R_CPPFLAGS -w ${OPTFLAGS}" \
     -DCMAKE_EXE_LINKER_FLAGS="$R_LDFLAGS" \
     -DCMAKE_SHARED_LINKER_FLAGS="$R_LDFLAGS" \
+    $LAUNCHER_ARGS \
     -DBUILD_DEV_TOOLS=OFF
   then
     echo


### PR DESCRIPTION
## :books: What?

This PR does two things:

* Rewrite the `configure` so it passes flags conditional on `ccache`-usage.
* CI/CD for remote install tests for 'regular' and cached builds.

Builds passes locally but not in PR as {pak} builds from default branch.

See issue https://github.com/serkor1/ta-lib-R/issues/57