### PR TITLE
fix: restore numeric vector outputs

### DIFF
--- a/R/ta_APO.R
+++ b/R/ta_APO.R
@@ -172,17 +172,9 @@ absolute_price_oscillator.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_APO.R
+++ b/R/ta_APO.R
@@ -172,9 +172,9 @@ absolute_price_oscillator.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_BBANDS.R
+++ b/R/ta_BBANDS.R
@@ -182,17 +182,9 @@ bollinger_bands.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_BBANDS.R
+++ b/R/ta_BBANDS.R
@@ -182,9 +182,9 @@ bollinger_bands.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_CMO.R
+++ b/R/ta_CMO.R
@@ -151,9 +151,9 @@ chande_momentum_oscillator.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_CMO.R
+++ b/R/ta_CMO.R
@@ -151,17 +151,9 @@ chande_momentum_oscillator.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_DEMA.R
+++ b/R/ta_DEMA.R
@@ -163,9 +163,9 @@ double_exponential_moving_average.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_DEMA.R
+++ b/R/ta_DEMA.R
@@ -163,17 +163,9 @@ double_exponential_moving_average.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_EMA.R
+++ b/R/ta_EMA.R
@@ -163,17 +163,9 @@ exponential_moving_average.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_EMA.R
+++ b/R/ta_EMA.R
@@ -163,9 +163,9 @@ exponential_moving_average.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_HT_DCPERIOD.R
+++ b/R/ta_HT_DCPERIOD.R
@@ -142,9 +142,9 @@ dominant_cycle_period.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_HT_DCPERIOD.R
+++ b/R/ta_HT_DCPERIOD.R
@@ -142,17 +142,9 @@ dominant_cycle_period.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_HT_DCPHASE.R
+++ b/R/ta_HT_DCPHASE.R
@@ -142,9 +142,9 @@ dominant_cycle_phase.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_HT_DCPHASE.R
+++ b/R/ta_HT_DCPHASE.R
@@ -142,17 +142,9 @@ dominant_cycle_phase.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_HT_PHASOR.R
+++ b/R/ta_HT_PHASOR.R
@@ -142,9 +142,9 @@ phasor_components.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_HT_PHASOR.R
+++ b/R/ta_HT_PHASOR.R
@@ -142,17 +142,9 @@ phasor_components.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_HT_SINE.R
+++ b/R/ta_HT_SINE.R
@@ -142,9 +142,9 @@ sine_wave.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_HT_SINE.R
+++ b/R/ta_HT_SINE.R
@@ -142,17 +142,9 @@ sine_wave.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_HT_TRENDLINE.R
+++ b/R/ta_HT_TRENDLINE.R
@@ -142,9 +142,9 @@ trendline.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_HT_TRENDLINE.R
+++ b/R/ta_HT_TRENDLINE.R
@@ -142,17 +142,9 @@ trendline.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_HT_TRENDMODE.R
+++ b/R/ta_HT_TRENDMODE.R
@@ -142,9 +142,9 @@ trend_cycle_mode.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_HT_TRENDMODE.R
+++ b/R/ta_HT_TRENDMODE.R
@@ -142,17 +142,9 @@ trend_cycle_mode.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_KAMA.R
+++ b/R/ta_KAMA.R
@@ -163,9 +163,9 @@ kaufman_adaptive_moving_average.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_KAMA.R
+++ b/R/ta_KAMA.R
@@ -163,17 +163,9 @@ kaufman_adaptive_moving_average.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_MACD.R
+++ b/R/ta_MACD.R
@@ -172,9 +172,9 @@ moving_average_convergence_divergence.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_MACD.R
+++ b/R/ta_MACD.R
@@ -172,17 +172,9 @@ moving_average_convergence_divergence.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_MACDEXT.R
+++ b/R/ta_MACDEXT.R
@@ -178,9 +178,9 @@ extended_moving_average_convergence_divergence.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_MACDEXT.R
+++ b/R/ta_MACDEXT.R
@@ -178,17 +178,9 @@ extended_moving_average_convergence_divergence.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_MACDFIX.R
+++ b/R/ta_MACDFIX.R
@@ -152,9 +152,9 @@ fixed_moving_average_convergence_divergence.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_MACDFIX.R
+++ b/R/ta_MACDFIX.R
@@ -152,17 +152,9 @@ fixed_moving_average_convergence_divergence.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_MAMA.R
+++ b/R/ta_MAMA.R
@@ -182,9 +182,9 @@ mesa_adaptive_moving_average.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_MAMA.R
+++ b/R/ta_MAMA.R
@@ -182,17 +182,9 @@ mesa_adaptive_moving_average.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_MOM.R
+++ b/R/ta_MOM.R
@@ -151,9 +151,9 @@ momentum.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_MOM.R
+++ b/R/ta_MOM.R
@@ -151,17 +151,9 @@ momentum.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_PPO.R
+++ b/R/ta_PPO.R
@@ -172,17 +172,9 @@ percentage_price_oscillator.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_PPO.R
+++ b/R/ta_PPO.R
@@ -172,9 +172,9 @@ percentage_price_oscillator.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_ROC.R
+++ b/R/ta_ROC.R
@@ -151,17 +151,9 @@ rate_of_change.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_ROC.R
+++ b/R/ta_ROC.R
@@ -151,9 +151,9 @@ rate_of_change.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_ROCR.R
+++ b/R/ta_ROCR.R
@@ -151,9 +151,9 @@ ratio_of_change.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_ROCR.R
+++ b/R/ta_ROCR.R
@@ -151,17 +151,9 @@ ratio_of_change.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_RSI.R
+++ b/R/ta_RSI.R
@@ -151,17 +151,9 @@ relative_strength_index.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_RSI.R
+++ b/R/ta_RSI.R
@@ -151,9 +151,9 @@ relative_strength_index.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_SMA.R
+++ b/R/ta_SMA.R
@@ -163,9 +163,9 @@ simple_moving_average.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_SMA.R
+++ b/R/ta_SMA.R
@@ -163,17 +163,9 @@ simple_moving_average.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_STOCHRSI.R
+++ b/R/ta_STOCHRSI.R
@@ -173,17 +173,9 @@ stochastic_relative_strength_index.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_STOCHRSI.R
+++ b/R/ta_STOCHRSI.R
@@ -173,9 +173,9 @@ stochastic_relative_strength_index.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_T3.R
+++ b/R/ta_T3.R
@@ -173,9 +173,9 @@ t3_exponential_moving_average.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_T3.R
+++ b/R/ta_T3.R
@@ -173,17 +173,9 @@ t3_exponential_moving_average.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_TEMA.R
+++ b/R/ta_TEMA.R
@@ -163,9 +163,9 @@ triple_exponential_moving_average.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_TEMA.R
+++ b/R/ta_TEMA.R
@@ -163,17 +163,9 @@ triple_exponential_moving_average.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_TRIMA.R
+++ b/R/ta_TRIMA.R
@@ -163,9 +163,9 @@ triangular_moving_average.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_TRIMA.R
+++ b/R/ta_TRIMA.R
@@ -163,17 +163,9 @@ triangular_moving_average.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_TRIX.R
+++ b/R/ta_TRIX.R
@@ -151,17 +151,9 @@ triple_exponential_average.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_TRIX.R
+++ b/R/ta_TRIX.R
@@ -151,9 +151,9 @@ triple_exponential_average.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_VOLUME.R
+++ b/R/ta_VOLUME.R
@@ -159,17 +159,9 @@ trading_volume.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/ta_VOLUME.R
+++ b/R/ta_VOLUME.R
@@ -159,9 +159,9 @@ trading_volume.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_WMA.R
+++ b/R/ta_WMA.R
@@ -163,9 +163,9 @@ weighted_moving_average.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## convert one-column matrix outputs
-	## to a double vector for vector input
-	x <- as_numeric_output(x)
+	if (dim(x)[2] == 1L) {
+		x <- as.double(x)
+	}
 
 	x
 }

--- a/R/ta_WMA.R
+++ b/R/ta_WMA.R
@@ -163,17 +163,9 @@ weighted_moving_average.numeric <- function(
 		as.logical(na.bridge)
 	)
 
-	## check if it has 'dims'
-	## and convert to double if
-	## not to honor the 'type-safety'-esque
-	## approach
-	##
-	## NOTE: this adds a few ns overhead but
-	##       its a robust alternative to code it
-	##       manually. Any suggestions are welcome
-	if (is.null(dim(x))) {
-		x <- as.double(x)
-	}
+	## convert one-column matrix outputs
+	## to a double vector for vector input
+	x <- as_numeric_output(x)
 
 	x
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -152,23 +152,6 @@ assert_column_names <- function(formula, available_variables) {
 	x
 }
 
-as_numeric_output <- function(x) {
-	lookback <- attr(x, "lookback", exact = TRUE)
-
-	if (is.matrix(x)) {
-		if (ncol(x) != 1L) {
-			return(x)
-		}
-
-		x <- x[, 1L]
-	}
-
-	x <- as.double(x)
-	attr(x, "lookback") <- lookback
-
-	x
-}
-
 ## class related utility
 ## functions
 is.formula <- function(x) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -152,6 +152,23 @@ assert_column_names <- function(formula, available_variables) {
 	x
 }
 
+as_numeric_output <- function(x) {
+	lookback <- attr(x, "lookback", exact = TRUE)
+
+	if (is.matrix(x)) {
+		if (ncol(x) != 1L) {
+			return(x)
+		}
+
+		x <- x[, 1L]
+	}
+
+	x <- as.double(x)
+	attr(x, "lookback") <- lookback
+
+	x
+}
+
 ## class related utility
 ## functions
 is.formula <- function(x) {

--- a/codegen/generate_unit-tests.sh
+++ b/codegen/generate_unit-tests.sh
@@ -345,19 +345,15 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		${FUN}(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })
 EOF

--- a/codegen/templates/moving_average_template.R.in
+++ b/codegen/templates/moving_average_template.R.in
@@ -155,9 +155,9 @@ $FUN.numeric <- function(
 			as.logical(na.bridge)
 		)
 
-		## convert one-column matrix outputs
-		## to a double vector for vector input
-		x <- as_numeric_output(x)
+		if (dim(x)[2] == 1L) {
+			x <- as.double(x)
+		}
 
 		x
 

--- a/codegen/templates/moving_average_template.R.in
+++ b/codegen/templates/moving_average_template.R.in
@@ -155,17 +155,9 @@ $FUN.numeric <- function(
 			as.logical(na.bridge)
 		)
 
-		## check if it has 'dims'
-		## and convert to double if
-		## not to honor the 'type-safety'-esque
-		## approach
-		##
-		## NOTE: this adds a few ns overhead but
-		##       its a robust alternative to code it
-		##       manually. Any suggestions are welcome
-		if (is.null(dim(x))) {
-			x <- as.double(x)
-		}
+		## convert one-column matrix outputs
+		## to a double vector for vector input
+		x <- as_numeric_output(x)
 
 		x
 

--- a/codegen/templates/numeric_template.R.in
+++ b/codegen/templates/numeric_template.R.in
@@ -26,17 +26,9 @@ ${FUN}.numeric <- function(
 			as.logical(na.bridge)
 		)
 
-		## check if it has 'dims'
-		## and convert to double if
-		## not to honor the 'type-safety'-esque
-		## approach
-		##
-		## NOTE: this adds a few ns overhead but
-		##       its a robust alternative to code it
-		##       manually. Any suggestions are welcome
-		if (is.null(dim(x))) {
-			x <- as.double(x)
-		}
+		## convert one-column matrix outputs
+		## to a double vector for vector input
+		x <- as_numeric_output(x)
 
 		x
 }

--- a/codegen/templates/numeric_template.R.in
+++ b/codegen/templates/numeric_template.R.in
@@ -26,9 +26,9 @@ ${FUN}.numeric <- function(
 			as.logical(na.bridge)
 		)
 
-		## convert one-column matrix outputs
-		## to a double vector for vector input
-		x <- as_numeric_output(x)
+		if (dim(x)[2] == 1L) {
+			x <- as.double(x)
+		}
 
 		x
 }

--- a/tests/testthat/test-ta_APO.R
+++ b/tests/testthat/test-ta_APO.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		absolute_price_oscillator(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_BBANDS.R
+++ b/tests/testthat/test-ta_BBANDS.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		bollinger_bands(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_CMO.R
+++ b/tests/testthat/test-ta_CMO.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		chande_momentum_oscillator(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_DEMA.R
+++ b/tests/testthat/test-ta_DEMA.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		double_exponential_moving_average(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_EMA.R
+++ b/tests/testthat/test-ta_EMA.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		exponential_moving_average(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_HT_DCPERIOD.R
+++ b/tests/testthat/test-ta_HT_DCPERIOD.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		dominant_cycle_period(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_HT_DCPHASE.R
+++ b/tests/testthat/test-ta_HT_DCPHASE.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		dominant_cycle_phase(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_HT_PHASOR.R
+++ b/tests/testthat/test-ta_HT_PHASOR.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		phasor_components(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_HT_SINE.R
+++ b/tests/testthat/test-ta_HT_SINE.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		sine_wave(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_HT_TRENDLINE.R
+++ b/tests/testthat/test-ta_HT_TRENDLINE.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		trendline(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_HT_TRENDMODE.R
+++ b/tests/testthat/test-ta_HT_TRENDMODE.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		trend_cycle_mode(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_KAMA.R
+++ b/tests/testthat/test-ta_KAMA.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		kaufman_adaptive_moving_average(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_MACD.R
+++ b/tests/testthat/test-ta_MACD.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		moving_average_convergence_divergence(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_MACDEXT.R
+++ b/tests/testthat/test-ta_MACDEXT.R
@@ -249,18 +249,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		extended_moving_average_convergence_divergence(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_MACDFIX.R
+++ b/tests/testthat/test-ta_MACDFIX.R
@@ -243,18 +243,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		fixed_moving_average_convergence_divergence(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_MAMA.R
+++ b/tests/testthat/test-ta_MAMA.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		mesa_adaptive_moving_average(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_MOM.R
+++ b/tests/testthat/test-ta_MOM.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		momentum(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_PPO.R
+++ b/tests/testthat/test-ta_PPO.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		percentage_price_oscillator(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_ROC.R
+++ b/tests/testthat/test-ta_ROC.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		rate_of_change(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_ROCR.R
+++ b/tests/testthat/test-ta_ROCR.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		ratio_of_change(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_RSI.R
+++ b/tests/testthat/test-ta_RSI.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		relative_strength_index(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_SMA.R
+++ b/tests/testthat/test-ta_SMA.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		simple_moving_average(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_STOCHRSI.R
+++ b/tests/testthat/test-ta_STOCHRSI.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		stochastic_relative_strength_index(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_T3.R
+++ b/tests/testthat/test-ta_T3.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		t3_exponential_moving_average(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_TEMA.R
+++ b/tests/testthat/test-ta_TEMA.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		triple_exponential_moving_average(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_TRIMA.R
+++ b/tests/testthat/test-ta_TRIMA.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		triangular_moving_average(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_TRIX.R
+++ b/tests/testthat/test-ta_TRIX.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		triple_exponential_average(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })

--- a/tests/testthat/test-ta_WMA.R
+++ b/tests/testthat/test-ta_WMA.R
@@ -240,18 +240,14 @@ testthat::test_that(desc = '<numeric> methods', code = {
 		weighted_moving_average(BTC[[1]])
 	)
 
-	## the numeric methods returns <matrix>
-	## depending on the underlying functions
-	## so the checks for equal lengths is conditional
 	target_length <- length(BTC[[1]])
 
-	if (is.null(dim(x))) {
-		testthat::expect_true(
-			length(x) == target_length
-		)
+	if (NCOL(x) == 1L) {
+		testthat::expect_true(is.double(x))
+		testthat::expect_false(is.matrix(x))
+		testthat::expect_equal(length(x), target_length)
 	} else {
-		testthat::expect_true(
-			nrow(x) == target_length
-		)
+		testthat::expect_true(is.matrix(x))
+		testthat::expect_equal(nrow(x), target_length)
 	}
 })


### PR DESCRIPTION
## Summary
- normalize one-column numeric indicator outputs back to double vectors
- update the generated numeric templates so future wrappers keep the same behavior
- tighten generated numeric tests to reject one-column matrix results while preserving multi-column matrix outputs

## Validation
- `bash -n codegen/generate_unit-tests.sh`
- `git diff --check`
- `rg "is.null\(dim\(x\)\)|numeric methods returns <matrix>" R codegen tests -n` (no matches)
- Not run: R/testthat suite; `R`/`Rscript` are unavailable in this environment.

Fixes #61