### PR TITLE
:hammer: Disable remote installs for R-devel

### DIFF
--- a/.github/workflows/remote-install.yaml
+++ b/.github/workflows/remote-install.yaml
@@ -34,19 +34,19 @@ jobs:
       matrix:
         config:
           ## macOS
-          - {os: macos-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: macos-latest,   r: 'release'}
           - {os: macos-latest,   r: 'oldrel-1'}
+          - {os: macos-latest,   r: 'oldrel-2'}
 
           ## windows
-          - {os: windows-latest, r: 'devel', http-user-agent: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: windows-latest, r: 'oldrel-1'}
+          - {os: windows-latest, r: 'oldrel-2'}
 
           # Ubuntu
-          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: ubuntu-latest,   r: 'oldrel-2'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -92,19 +92,19 @@ jobs:
       matrix:
         config:
           ## macOS
-          - {os: macos-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: macos-latest,   r: 'release'}
           - {os: macos-latest,   r: 'oldrel-1'}
+          - {os: macos-latest,   r: 'oldrel-2'}
 
           ## windows
-          - {os: windows-latest, r: 'devel', http-user-agent: 'release'}
           - {os: windows-latest, r: 'release'}
           - {os: windows-latest, r: 'oldrel-1'}
+          - {os: windows-latest, r: 'oldrel-2'}
 
           # Ubuntu
-          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: ubuntu-latest,   r: 'oldrel-2'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* See issue https://github.com/serkor1/ta-lib-R/issues/67 where remote installs fails on MacOS due to missing C header files. The error is related to gettext (source: https://stackoverflow.com/questions/11370684/what-is-libintl-h-and-where-can-i-get-it)

  The issue have not been addressed in the repository before now as it was assumed to be related to the workflow itself - the failed run coincided with the release of R4.6.0 which turned out to be a false-positive as it still an existing issue.

* Since the issue is most likely an upstream issue, the R-devel runs have been removed for all OSes and replaced with oldrel-2.

  Backwards compatibility is more imporant than experimental releases - if you decide to throw a development version of R against a package that deals with (potentially) expensive implementations, you have bigger things to worry about.